### PR TITLE
Convert URDF to MJCF for MuJoCo uses

### DIFF
--- a/MuJoCo/bruce.xml
+++ b/MuJoCo/bruce.xml
@@ -1,0 +1,135 @@
+<mujoco model="bruce">
+  <compiler angle="radian" meshdir="../Gazebo/models/bruce/meshes" autolimits="true"/>
+
+  <asset>
+    <mesh name="base_link" file="base_link.STL"/>
+    <mesh name="hip_yaw_link_r" file="hip_yaw_link_r.STL"/>
+    <mesh name="hip_roll_link_r" file="hip_roll_link_r.STL"/>
+    <mesh name="hip_pitch_link_r" file="hip_pitch_link_r.STL"/>
+    <mesh name="knee_pitch_link_r" file="knee_pitch_link_r.STL"/>
+    <mesh name="ankle_pitch_link_r" file="ankle_pitch_link_r.STL"/>
+    <mesh name="hip_yaw_link_l" file="hip_yaw_link_l.STL"/>
+    <mesh name="hip_roll_link_l" file="hip_roll_link_l.STL"/>
+    <mesh name="hip_pitch_link_l" file="hip_pitch_link_l.STL"/>
+    <mesh name="knee_pitch_link_l" file="knee_pitch_link_l.STL"/>
+    <mesh name="ankle_pitch_link_l" file="ankle_pitch_link_l.STL"/>
+    <mesh name="shoulder_pitch_link_r" file="shoulder_pitch_link_r.STL"/>
+    <mesh name="shoulder_roll_link_r" file="shoulder_roll_link_r.STL"/>
+    <mesh name="elbow_pitch_link_r" file="elbow_pitch_link_r.STL"/>
+    <mesh name="shoulder_pitch_link_l" file="shoulder_pitch_link_l.STL"/>
+    <mesh name="shoulder_roll_link_l" file="shoulder_roll_link_l.STL"/>
+    <mesh name="elbow_pitch_link_l" file="elbow_pitch_link_l.STL"/>
+  </asset>
+  <worldbody>
+    <body name="base_link" pos="0 0 0.47">
+      <freejoint/>
+      <inertial pos="0.02259605 -0.00011305 0.06140054" mass="1.31688922" diaginertia="0.0133543 0.01023631 0.005471"/>
+      <geom name="body" type="mesh" mesh="base_link" rgba="0.752941176 0.752941176 0.752941176 1"/>
+
+      <!-- RIGHT LEG -->
+      <body name="hip_yaw_link_r" pos="0.029216 -0.0758557 -0.039765" quat="0.707107 0 0 -0.707107">
+        <inertial pos="2.71e-06 -0.00024824 0.00522427" quat="0.517691 0.482114 0.518083 0.480784" mass="0.637563" diaginertia="0.0016174 0.00152078 0.000485406"/>
+        <joint name="hip_yaw_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_yaw_link_r"/>
+        <body name="hip_roll_link_r" quat="0.5 -0.5 0.5 0.5">
+          <inertial pos="-1.51e-07 0 6.88e-06" mass="0.05" diaginertia="1e-05 1e-05 1e-05"/>
+          <joint name="hip_roll_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_roll_link_r"/>
+          <body name="hip_pitch_link_r" quat="0.707107 0.707107 0 0">
+            <inertial pos="0.140714 -0.0086817 0.00167429" quat="-0.0210718 0.710934 0.00543456 0.702922" mass="0.72849" diaginertia="0.0181996 0.0179488 0.000479326"/>
+            <joint name="hip_pitch_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+            <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_pitch_link_r"/>
+            <body name="knee_pitch_link_r" pos="0.204949 0 0">
+              <inertial pos="0.0729308 0.0174645 0.00216432" quat="-0.0124752 0.71085 -0.0538621 0.701167" mass="0.0956654" diaginertia="0.00108397 0.00102192 0.000106307"/>
+              <joint name="knee_pitch_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+              <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="knee_pitch_link_r"/>
+              <body name="ankle_pitch_link_r" pos="0.199881 0 0">
+                <inertial pos="0.0120775 0.0019746 0.00029511" quat="0.443128 0.545146 -0.456612 0.545855" mass="0.0276265" diaginertia="2.58838e-05 2.09859e-05 5.64035e-06"/>
+                <joint name="ankle_pitch_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+                <geom type="mesh" rgba="0.792157 0.819608 0.933333 1" mesh="ankle_pitch_link_r"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <!-- LEFT LEG -->
+      <body name="hip_yaw_link_l" pos="0.029216 0.0758557 -0.039765" quat="0.707107 0 0 -0.707107">
+        <inertial pos="0 -0.00020849 0.00528032" quat="0.518836 0.480432 0.518756 0.480506" mass="0.637386" diaginertia="0.00161868 0.00152047 0.0004852"/>
+        <joint name="hip_yaw_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_yaw_link_l"/>
+        <body name="hip_roll_link_l" quat="0.500001 -0.499999 0.500001 0.499999">
+          <inertial pos="-1.51e-07 0 6.88e-06" mass="0.05" diaginertia="1e-05 1e-05 1e-05"/>
+          <joint name="hip_roll_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_roll_link_l"/>
+          <body name="hip_pitch_link_l" quat="0.707107 0.707107 0 0">
+            <inertial pos="0.142447 -0.00832054 0.00049317" quat="-0.002203 0.702817 0.024599 0.710942" mass="0.720628" diaginertia="0.018195 0.0179541 0.000461885"/>
+            <joint name="hip_pitch_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+            <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_pitch_link_l"/>
+            <body name="knee_pitch_link_l" pos="0.204949 0 0">
+              <inertial pos="0.0730996 0.0178102 -0.00219767" quat="0.0505999 0.70058 0.00930476 0.711716" mass="0.0952654" diaginertia="0.00107995 0.00101966 0.000104635"/>
+              <joint name="knee_pitch_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+              <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="knee_pitch_link_l"/>
+              <body name="ankle_pitch_link_l" pos="0.199881 0 0">
+                <inertial pos="0.0123398 0.00253004 -0.00030441" quat="0.455603 0.546571 -0.442281 0.545962" mass="0.0274829" diaginertia="2.60237e-05 2.09939e-05 5.69233e-06"/>
+                <joint name="ankle_pitch_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+                <geom type="mesh" rgba="0.792157 0.819608 0.933333 1" mesh="ankle_pitch_link_l"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <!-- RIGHT ARM -->
+      <body name="shoulder_pitch_link_r" pos="0.029216 -0.12375 0.152985" quat="0.5 0.5 -0.5 0.5">
+        <inertial pos="0 -0.00038323 -0.0141368" quat="0.999984 0.0057278 0 0" mass="0.0493169" diaginertia="2.507e-05 2.40321e-05 8.31794e-06"/>
+        <joint name="shoulder_pitch_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="shoulder_pitch_link_r"/>
+        <body name="shoulder_roll_link_r" quat="0.5 0.5 -0.5 0.5">
+          <inertial pos="0.0570939 -0.00419463 0.00093738" quat="-0.205082 0.694437 -0.169487 0.66856" mass="0.024" diaginertia="0.000126403 0.000125807 7.29e-06"/>
+          <joint name="shoulder_roll_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="shoulder_roll_link_r"/>
+          <body name="elbow_pitch_link_r" pos="0.1146 -0.005 0.005" quat="0.707107 0.707107 0 0">
+            <inertial pos="0.0217884 0 0.0003604" quat="0.499291 0.500708 0.500708 0.499291" mass="0.0524404" diaginertia="7.261e-05 7.10305e-05 7.52949e-06"/>
+            <joint name="elbow_pitch_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+            <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="elbow_pitch_link_r"/>
+          </body>
+        </body>
+      </body>
+      <!-- LEFT ARM -->
+      <body name="shoulder_pitch_link_l" pos="0.029216 0.12375 0.152985" quat="0.5 -0.5 0.5 0.5">
+        <inertial pos="0 0.00038323 -0.0141368" quat="0.999984 -0.0057278 0 0" mass="0.0493169" diaginertia="2.507e-05 2.40321e-05 8.31794e-06"/>
+        <joint name="shoulder_pitch_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="shoulder_pitch_link_l"/>
+        <body name="shoulder_roll_link_l" quat="0.5 0.5 -0.5 0.5">
+          <inertial pos="0.0570939 0.00419463 0.00094155" quat="0.207025 0.693936 0.171489 0.667971" mass="0.0313652" diaginertia="0.000165195 0.000164406 9.52871e-06"/>
+          <joint name="shoulder_roll_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="shoulder_roll_link_l"/>
+          <body name="elbow_pitch_link_l" pos="0.1146 0.005 0.005" quat="0.707107 -0.707107 0 0">
+            <inertial pos="0.0217884 0 0.0003604" quat="0.499291 0.500708 0.500708 0.499291" mass="0.0524404" diaginertia="7.261e-05 7.10305e-05 7.52949e-06"/>
+            <joint name="elbow_pitch_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
+            <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="elbow_pitch_link_l"/>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <motor name="hip_yaw_r" joint='hip_yaw_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="hip_roll_r" joint='hip_roll_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="hip_pitch_r" joint='hip_pitch_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="knee_pitch_r" joint='knee_pitch_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="ankle_pitch_r" joint='ankle_pitch_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="hip_yaw_l" joint='hip_yaw_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="hip_roll_l" joint='hip_roll_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="hip_pitch_l" joint='hip_pitch_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="knee_pitch_l" joint='knee_pitch_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="ankle_pitch_l" joint='ankle_pitch_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="shoulder_pitch_r" joint='shoulder_pitch_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="shoulder_roll_r" joint='shoulder_roll_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="elbow_pitch_r" joint='elbow_pitch_r' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="shoulder_pitch_l" joint='shoulder_pitch_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="shoulder_roll_l" joint='shoulder_roll_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+    <motor name="elbow_pitch_l" joint='elbow_pitch_l' gear="1 0 0 0 0 0" ctrlrange='-200 200'/>
+  </actuator>
+
+</mujoco>

--- a/MuJoCo/bruce.xml
+++ b/MuJoCo/bruce.xml
@@ -30,11 +30,11 @@
       <body name="hip_yaw_link_r" pos="0.029216 -0.0758557 -0.039765" quat="0.707107 0 0 -0.707107">
         <inertial pos="2.71e-06 -0.00024824 0.00522427" quat="0.517691 0.482114 0.518083 0.480784" mass="0.637563" diaginertia="0.0016174 0.00152078 0.000485406"/>
         <joint name="hip_yaw_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
-        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_yaw_link_r"/>
+        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_yaw_link_r" contype="0" conaffinity="0"/>
         <body name="hip_roll_link_r" quat="0.5 -0.5 0.5 0.5">
           <inertial pos="-1.51e-07 0 6.88e-06" mass="0.05" diaginertia="1e-05 1e-05 1e-05"/>
           <joint name="hip_roll_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
-          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_roll_link_r"/>
+          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_roll_link_r" contype="0" conaffinity="0"/>
           <body name="hip_pitch_link_r" quat="0.707107 0.707107 0 0">
             <inertial pos="0.140714 -0.0086817 0.00167429" quat="-0.0210718 0.710934 0.00543456 0.702922" mass="0.72849" diaginertia="0.0181996 0.0179488 0.000479326"/>
             <joint name="hip_pitch_r" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
@@ -56,11 +56,11 @@
       <body name="hip_yaw_link_l" pos="0.029216 0.0758557 -0.039765" quat="0.707107 0 0 -0.707107">
         <inertial pos="0 -0.00020849 0.00528032" quat="0.518836 0.480432 0.518756 0.480506" mass="0.637386" diaginertia="0.00161868 0.00152047 0.0004852"/>
         <joint name="hip_yaw_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
-        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_yaw_link_l"/>
+        <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_yaw_link_l" contype="0" conaffinity="0"/>
         <body name="hip_roll_link_l" quat="0.500001 -0.499999 0.500001 0.499999">
           <inertial pos="-1.51e-07 0 6.88e-06" mass="0.05" diaginertia="1e-05 1e-05 1e-05"/>
           <joint name="hip_roll_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>
-          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_roll_link_l"/>
+          <geom type="mesh" rgba="0.752941 0.752941 0.752941 1" mesh="hip_roll_link_l" contype="0" conaffinity="0"/>
           <body name="hip_pitch_link_l" quat="0.707107 0.707107 0 0">
             <inertial pos="0.142447 -0.00832054 0.00049317" quat="-0.002203 0.702817 0.024599 0.710942" mass="0.720628" diaginertia="0.018195 0.0179541 0.000461885"/>
             <joint name="hip_pitch_l" pos="0 0 0" axis="0 0 1" limited="true" range="-3.1415 3.1415"/>

--- a/MuJoCo/scene.xml
+++ b/MuJoCo/scene.xml
@@ -1,0 +1,34 @@
+<mujoco model="bruce scene">
+    <include file="bruce.xml"/>
+  
+    <statistic center="0 0 1" extent="1.8"/>
+  
+    <option timestep="0.001" gravity="0 0 -9.81" tolerance="1e-05" cone="elliptic" jacobian="dense" solver="Newton"  noslip_iterations="10" integrator="Euler" iterations="30" impratio="10.0"/> 
+    <option>
+      <flag override="enable" gravity="enable"/>
+    </option>
+
+    <default>
+      <joint limited="false" damping="2" armature="0.1" stiffness="0" frictionloss="0.2"/>
+      <motor gear="1 0 0 0 0 0" ctrllimited="false" ctrlrange="-100 100"/>
+    </default>
+
+    <visual>
+      <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+      <rgba haze="0.15 0.25 0.35 1"/>
+      <global azimuth="160" elevation="-20"/>
+    </visual>
+  
+    <asset>
+      <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+      <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+        markrgb="0.8 0.8 0.8" width="300" height="300"/>
+      <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+    </asset>
+  
+    <worldbody>
+      <light pos="0 0 3.5" dir="0 0 -1" directional="true"/>
+      <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+    </worldbody>
+  
+  </mujoco>


### PR DESCRIPTION
### Updates
I briefly converted bruce.urdf to bruce.xml by using compile option that MuJoCo provides.

There are some differences between the urdf and converted xml, which are
1. URDF uses full inertia, and MuJoCo uses Diagonal Inertia ( I have tried to set full inertia matrix; but, there are some error occurs during the inertia conversion )
2. Link Collision Issue ( I have modified the contact option of the geometry of hip yaw and roll links.)
3. I have made the scene based on the options provided by [mujoco_menagerie](https://github.com/google-deepmind/mujoco_menagerie)

### TL;DR
I have briefly converted it to my taste, and it is now able to use the Bruce model as MJCF. However, some improvements are still needed to satisfy the [mujoco_menagerie](https://github.com/google-deepmind/mujoco_menagerie) model quality, maybe grade A~B.

### Simple joint pd controlled bruce. 

https://github.com/Westwood-Robotics/BRUCE_simulation_models/assets/50351712/85a74990-25fa-4865-b767-066dc97043e2